### PR TITLE
fix: requestPty before shell

### DIFF
--- a/sshio.go
+++ b/sshio.go
@@ -22,12 +22,12 @@ func NewSessionIO(session *ssh.Session) (r io.Reader, w io.Writer, err error) {
 		return
 	}
 
-	err = session.Shell()
+	err = session.RequestPty("xterm", 80, 40, ssh.TerminalModes{})
 	if err != nil {
 		return
 	}
 
-	err = session.RequestPty("xterm", 80, 40, ssh.TerminalModes{})
+	err = session.Shell()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
request pty before starting shell

[gliderlabs/ssh](https://github.com/gliderlabs/ssh/blob/master/session.go#L320-L324)
default session handler will reject pty-req's for handled sessions.